### PR TITLE
dplyr 0.8.4: arguments of the group_modify() generic have changed

### DIFF
--- a/R/dplyr_methods.r
+++ b/R/dplyr_methods.r
@@ -573,9 +573,9 @@ group_split.egor <- function(.tbl, ...) {
 #' @export
 #' @noRd
 #' @method group_modify egor
-group_modify.egor <- function(.tbl, .f, ...) {
-  result <- group_modify(.tbl[[attr(.tbl, "active")]], .f, ...)
-  return_egor_with_result(.tbl, result)
+group_modify.egor <- function(.data, .f, ..., keep = FALSE) {
+  result <- group_modify(.data[[attr(.data, "active")]], .f, ..., keep = keep)
+  return_egor_with_result(.data, result)
 }
 
 #' #' @export


### PR DESCRIPTION
Results for revdep checks for the dplyr 0.8.4 release candidate. 

````
# egor

<details>

* Version: 0.19.10
* Source code: https://github.com/cran/egor
* URL: https://github.com/tilltnet/egor, https://tilltnet.github.io/egor/
* BugReports: https://github.com/tilltnet/egor/issues
* Date/Publication: 2019-10-07 22:10:06 UTC
* Number of recursive dependencies: 61

Run `revdep_details(,"egor")` for more info

</details>

## Newly broken

*   checking S3 generic/method consistency ... WARNING
    ```
    group_modify:
      function(.data, .f, ..., keep)
    group_modify.egor:
      function(.tbl, .f, ...)
    
    See section ‘Generic functions and methods’ in the ‘Writing R
    Extensions’ manual.
    ```
````
