### PR TITLE
required more recent R version since this uses |>

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ URL: https://github.com/tilltnet/egor, https://egor.tillt.net/
 BugReports: https://github.com/tilltnet/egor/issues
 License: AGPL-3
 Depends:
-    R (>= 3.5.0),
+    R (>= 4.1.0),
     dplyr,
     tibble
 Imports:


### PR DESCRIPTION
The `|>` appeared in R 4.1, so requiring it, otherwise some tests fail to parse.  