### PR TITLE
Add note about density being calculated with ego removd

### DIFF
--- a/R/density.R
+++ b/R/density.R
@@ -3,9 +3,9 @@
 #' Calculate the relationship density in ego-centered networks
 #'
 #' This function uses an \code{egor} object and calculates the density of all
-#' the ego-centered networks listed in the 'egor' object. Instead of an
-#' \code{egor} object, alter and alter-alter data can be provided as \code{lists}
-#' or \code{data.frames}.
+#' the ego-centered networks listed in the 'egor' object. The density is calculated
+#' with ego removed. Instead of an \code{egor} object, alter and alter-alter
+#' data can be provided as \code{lists} or \code{data.frames}.
 #' @template object
 #' @param max.netsize Optional parameter. Constant value used if the
 #' number of alters whose relations were collected is limited.


### PR DESCRIPTION
It appears that the ego_density function calculates density with ego removed, which makes sense. This notes that in the documentation.