### PR TITLE
Allow displaying plots when there are no alter-alter ties

### DIFF
--- a/R/plot_ego_graph.R
+++ b/R/plot_ego_graph.R
@@ -189,7 +189,18 @@ plot_one_ego_graph <- function(x,
     # Set curvature of ego-alter ties to zero
     # igraph::E(gr)$curved[is.na(igraph::E(gr)$curved)] <- 0
     # Set ego-alter weights to a dummy value
-    igraph::E(gr)$weight[is.na(igraph::E(gr)$weight)] <- min(igraph::E(gr)$weight, na.rm = TRUE)
+    if (any(!is.na(igraph::E(gr)$weight))) {
+      # Set to min of other weights, so scale of weights is comparable
+      igraph::E(gr)$weight[is.na(igraph::E(gr)$weight)] <- min(igraph::E(gr)$weight, na.rm = TRUE)
+    } else {
+      # no other weights in the graph, so just set a hardwired dummy value
+      # if there is no weight variable at all, E(gr)$weight will be NULL rather than a vector,
+      # so the syntax igraph::E(gr)$weight[is.na(igraph::E(gr)$weight)] will fail. Since all weights
+      # are NULL or NA at this point, set them all to 1. This will change missing aatie weights to 1,
+      # which may not be desirable, but overwriting missing aatie weights is also the behavior of the
+      # code above when there is at least one nonmissing aatie weight
+      igraph::E(gr)$weight <- 1
+    }
   }
   
   igraph::plot.igraph(

--- a/tests/testthat/test-plot_egor.R
+++ b/tests/testthat/test-plot_egor.R
@@ -148,6 +148,38 @@ test_that("plot_egograms doesn't fail on empty alters or aaties", {
   NA)
 })
 
+test_that("plot_ego_graphs doesn't fail on empty alters or aaties", {
+  e <- make_egor(5, 5)
+  e$aatie <-
+    e$aatie %>%
+    filter(.egoID != 1)
+  expect_error(plot_ego_graphs(
+    e, ego_id=1, include_ego=F
+  ),
+  NA)
+  
+  # test for #86
+  expect_error(plot_ego_graphs(
+    e, ego_id=1, include_ego=T
+  ),
+  NA)
+
+  e <- make_egor(5, 5)
+  e$alter <-
+    e$alter %>%
+    filter(.egoID != 1)
+    
+  expect_error(plot_ego_graphs(
+    e, ego_id=1, include_ego=F
+  ),
+  NA)
+  
+  expect_error(plot_ego_graphs(
+    e, ego_id=1, include_ego=T
+  ),
+  NA)
+})
+
 test_that("plot_egograms plots with and without venn labels", {
   expect_error({
     e <- make_egor(5, 5)


### PR DESCRIPTION
When there are no alter-alter ties, displaying an ego graph fails (#86). This is because the weight for the ego-alter ties is set to the minimum weight of all ties currently in the graph, but in this case there are no ties in the graph. This fix adds a special case for that situation. If all weights are NA (or if the entire weights vector is NULL), the weight is set to 1 for all ties (including both the intended ego-alter ties, as well as any aaties with NA weights; modifying aaties with null weights is the previous behavior but this might not be desirable).

Also, just above the changed code there is the line `set.seed(1337)`. Is that intentional? Seems like it could cause unexpected results in external code that relies on random numbers and isn't expecting global RNG state to be modified.